### PR TITLE
GAMBIO-328: added means by which total order weight is added to gambi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Fixed
 - sort order of products within categories with show sub products setting
 - coupon being given for deactivated customer group discount
+- total weight order now added to desktop order 
 
 ## 2.9.51
 ### Changed

--- a/src/shopgate/plugin.php
+++ b/src/shopgate/plugin.php
@@ -1413,6 +1413,9 @@ class ShopgatePluginGambioGX extends ShopgatePlugin
         $orderData["shipping_class"]  = $shippingInfos->getName()
             ? $shippingInfos->getName()
             : "flat_flat";
+        $orderData["order_total_weight"] = $shippingInfos->getWeight() > 0
+            ? $shippingInfos->getWeight() / 1000
+            : 0;
 
         $orderData["cc_type"]    = "";
         $orderData["cc_owner"]   = "";


### PR DESCRIPTION
…o order

Found that the shopgate plugin assumes the weight that is exported to shopgate is in the KG unit of measure. This is why the weight is divided by 1000 to convert grams to KG.

