### PR TITLE
GAMBIO-333: product image file names are now exported in a url encode…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - wrong total class for cash on delivery order fees, now using ot_cod_fee 
 - added check for Gambio version so order weight total is only added when the Gambio version supports this.
 - stock update when orders contains both a simple product and a product with a property
-- shopgate plugin can now find product images that are stored in the info_images directory
+- Shopgate plugin can now find product images that are stored in the info_images directory
 
 ## [2.9.52] - 2017-11-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - wrong total class for cash on delivery order fees, now using ot_cod_fee 
 - added check for Gambio version so order weight total is only added when the Gambio version supports this.
 - stock update when orders contains both a simple product and a product with a property
+- shopgate plugin can now find product images that are stored in the info_images directory
 
 ## [2.9.52] - 2017-11-06
 ### Added

--- a/src/shopgate/model/item/ShopgateItemModel.php
+++ b/src/shopgate/model/item/ShopgateItemModel.php
@@ -618,18 +618,22 @@ class ShopgateItemModel extends Shopgate_Model_Catalog_Product
 
         if (!empty($product['products_image'])) {
             if (file_exists(DIR_FS_CATALOG . DIR_WS_ORIGINAL_IMAGES . $product['products_image'])) {
-                $images[] = $this->getFilePath($product['products_image'], DIR_WS_ORIGINAL_IMAGES);
+                $images[] = $this->getFilePath(urlencode($product['products_image']), DIR_WS_ORIGINAL_IMAGES);
             } elseif (file_exists(DIR_FS_CATALOG . DIR_WS_POPUP_IMAGES . $product['products_image'])) {
-                $images[] = $this->getFilePath($product['products_image'], DIR_WS_POPUP_IMAGES);
+                $images[] = $this->getFilePath(urlencode($product['products_image']), DIR_WS_POPUP_IMAGES);
+            } elseif (file_exists(DIR_FS_CATALOG . DIR_WS_INFO_IMAGES . $product['products_image'])) {
+                $images[] = $this->getFilePath(urlencode($product['products_image']), DIR_WS_INFO_IMAGES);
             }
         }
 
         $query = xtc_db_query($qry);
         while ($image = xtc_db_fetch_array($query)) {
             if (file_exists(DIR_FS_CATALOG . DIR_WS_ORIGINAL_IMAGES . $image['image_name'])) {
-                $images[] = $this->getFilePath($image['image_name'], DIR_WS_ORIGINAL_IMAGES);
+                $images[] = $this->getFilePath(urlencode($image['image_name']), DIR_WS_ORIGINAL_IMAGES);
             } elseif (file_exists(DIR_FS_CATALOG . DIR_WS_POPUP_IMAGES . $image['image_name'])) {
-                $images[] = $this->getFilePath($image['image_name'], DIR_WS_POPUP_IMAGES);
+                $images[] = $this->getFilePath(urlencode($image['image_name']), DIR_WS_POPUP_IMAGES);
+            } elseif (file_exists(DIR_FS_CATALOG . DIR_WS_INFO_IMAGES . $image['image_name'])) {
+                $images[] = $this->getFilePath(urlencode($image['image_name']), DIR_WS_INFO_IMAGES);
             }
         }
 


### PR DESCRIPTION
…d format, and product images can be found in the info_images directory.

@Rekhyt 
If you are not able to do the review for this pull request please let me know and I will reassign it.

Thanks
Aaron